### PR TITLE
Delete custom events

### DIFF
--- a/h5p/development/H5P.FormulaApplet-2.10/scripts/formulaapplet.js
+++ b/h5p/development/H5P.FormulaApplet-2.10/scripts/formulaapplet.js
@@ -46,9 +46,8 @@ H5P.FormulaApplet = (function ($) {
 var chainTimerId = -1;
 var chainTimerInterval = 1000; //millisec
 var chainTimerFinished = function () {
-  console.log('last Timer ' + chainTimerId + ' finished.');
-  console.log(H5Pbridge);
-  H5P.jQuery(document).trigger('preparePageEvent');
+  console.log('last ChainTimer ' + chainTimerId + ' finished.');
+  H5Pbridge.preparePage();
   // preparePageEvent may be replaced by mathquillifyEvent(id) in constructor
 };
 
@@ -56,11 +55,11 @@ function chainTimer() {
   if (chainTimerId !== -1) {
     // stop timer, wait with chainTimerFinished
     clearTimeout(chainTimerId);
-    console.log('ChainTimer ' + chainTimerId + ' stopped.');
+    // console.log('ChainTimer ' + chainTimerId + ' stopped.');
   }
   // start next timer (or first timer) 
   chainTimerId = setTimeout(chainTimerFinished, chainTimerInterval);
-  console.log('Timer ' + chainTimerId + ' started.');
+  // console.log('Timer ' + chainTimerId + ' started.');
 }
 
 

--- a/h5p/development/H5P.FormulaApplet-2.10/scripts/formulaapplet.js
+++ b/h5p/development/H5P.FormulaApplet-2.10/scripts/formulaapplet.js
@@ -43,29 +43,29 @@ H5P.FormulaApplet = (function ($) {
   return C;
 })(H5P.jQuery);
 
-var chainTimerId = -1;
-var chainTimerInterval = 1000; //millisec
-var chainTimerFinished = function () {
-  console.log('last ChainTimer ' + chainTimerId + ' finished.');
-  H5Pbridge.preparePage();
-  // preparePageEvent may be replaced by mathquillifyEvent(id) in constructor
-};
+// var chainTimerId = -1;
+// var chainTimerInterval = 1000; //millisec
+// var chainTimerFinished = function () {
+//   console.log('last ChainTimer ' + chainTimerId + ' finished.');
+//   // H5Pbridge.preparePage();
+//   // preparePageEvent may be replaced by mathquillifyEvent(id) in constructor
+// };
 
-function chainTimer() {
-  if (chainTimerId !== -1) {
-    // stop timer, wait with chainTimerFinished
-    clearTimeout(chainTimerId);
-    // console.log('ChainTimer ' + chainTimerId + ' stopped.');
-  }
-  // start next timer (or first timer) 
-  chainTimerId = setTimeout(chainTimerFinished, chainTimerInterval);
-  // console.log('Timer ' + chainTimerId + ' started.');
-}
-
+// function chainTimer() {
+//   if (chainTimerId !== -1) {
+//     // stop timer, wait with chainTimerFinished
+//     clearTimeout(chainTimerId);
+//     // console.log('ChainTimer ' + chainTimerId + ' stopped.');
+//   }
+//   // start next timer (or first timer) 
+//   chainTimerId = setTimeout(chainTimerFinished, chainTimerInterval);
+//   // console.log('Timer ' + chainTimerId + ' started.');
+// }
 
 function afterAppend(id) {
   // self.$.trigger('resize');
   H5P.jQuery(document).trigger('resize');
+  H5Pbridge.mathQuillify(id);
   // wait with chainTimerFinished until the last timer has finished
-  chainTimer();
+  // chainTimer();
 }

--- a/h5p/development/H5PEditor.FormulaAppletEditor-1.1/scripts/formulaapplet-editor.js
+++ b/h5p/development/H5PEditor.FormulaAppletEditor-1.1/scripts/formulaapplet-editor.js
@@ -43,11 +43,12 @@ H5PEditor.widgets.formulaAppletEditor = H5PEditor.FormulaAppletEditor = (functio
     var params = self.parent.params;
     // params.TEX_expression = params.fa_applet;
 
+    var hasSolution = (params.formulaAppletMode == 'manu');
     var html = '<p class="formula_applet edit" id="' + params.id + '"';
     if (params.formulaAppletPhysics == true) {
       html += ' mode="physics"';
     }
-    if (params.formulaAppletMode == 'manu') {
+    if (hasSolution) {
       html += ' data-b64="' + params.data_b64 + '"';
     }
     var temp = params.TEX_expression;
@@ -122,7 +123,6 @@ H5PEditor.widgets.formulaAppletEditor = H5PEditor.FormulaAppletEditor = (functio
     console.log('*** MAIN is loaded *** ');
     console.log(H5Pbridge);
     console.log('before triggering preparePageEvent');
-    // postEvent("preparePageEvent");
     H5Pbridge.preparePage();
     var id = getputId.get();
     console.log(id);

--- a/h5p/development/H5PEditor.FormulaAppletEditor-1.1/scripts/formulaapplet-editor.js
+++ b/h5p/development/H5PEditor.FormulaAppletEditor-1.1/scripts/formulaapplet-editor.js
@@ -90,6 +90,7 @@ H5PEditor.widgets.formulaAppletEditor = H5PEditor.FormulaAppletEditor = (functio
       text: 'Set input field (Joubel)',
       click: function (event) {
         event.preventDefault();
+        console.log("post setInputFieldEvent click");
         postEvent(["setInputFieldEvent", "dummy data"]);
       }
     });
@@ -103,8 +104,8 @@ H5PEditor.widgets.formulaAppletEditor = H5PEditor.FormulaAppletEditor = (functio
     function buttonMouseoverHandler(ev) {
       ev.stopImmediatePropagation();
       ev.preventDefault();
+      console.log("post setInputFieldMouseoverEvent");
       postEvent(["setInputFieldMouseoverEvent", 'dummy data']);
-      console.log(H5Pbridge.makeid(150));
     };
 
     $(function () {
@@ -129,7 +130,7 @@ H5PEditor.widgets.formulaAppletEditor = H5PEditor.FormulaAppletEditor = (functio
       console.log('postEvent idChangedEvent with id=' + id);
       postEvent(["idChangedEvent", id]);
     }
-    postEvent(["testEvent", "data"]);
+    postEvent(["testEvent", "dummy data"]);
     var elem = document.getElementById('new_id');
     console.log(elem);
     H5P.jQuery(elem).attr('id', id)
@@ -185,7 +186,7 @@ function afterAppend(obj) {
     var idField = getField('id');
     console.log('idField.value=' + idField.value);
     if (idField.value == 'new_id') {
-      var newId = makeid(12);
+      var newId = H5Pbridge.makeid(12);
       console.log('new_id -> ' + newId);
       idField.value = idField.$input[0].value = newId;
       console.log('obj.parent.params.id=' + obj.parent.params.id);
@@ -332,15 +333,15 @@ function waitForMainThenDo(cont) {
 // End of waitForMain mechanism
 
 
-function makeid(length) {
-  var result = 'fa';
-  var characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-  var numOfChars = characters.length;
-  for (var i = 2; i < length; i++) {
-    result += characters.charAt(Math.floor(Math.random() * numOfChars));
-  }
-  return result;
-}
+// function makeid(length) {
+//   var result = 'fa';
+//   var characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+//   var numOfChars = characters.length;
+//   for (var i = 2; i < length; i++) {
+//     result += characters.charAt(Math.floor(Math.random() * numOfChars));
+//   }
+//   return result;
+// }
 
 function getSelectorID(selectorName) {
   var result = '';

--- a/h5p/development/H5PEditor.FormulaAppletEditor-1.1/scripts/formulaapplet-editor.js
+++ b/h5p/development/H5PEditor.FormulaAppletEditor-1.1/scripts/formulaapplet-editor.js
@@ -104,8 +104,7 @@ H5PEditor.widgets.formulaAppletEditor = H5PEditor.FormulaAppletEditor = (functio
       ev.stopImmediatePropagation();
       ev.preventDefault();
       postEvent(["setInputFieldMouseoverEvent", 'dummy data']);
-      console.log('test export/import of function');
-      console.log(faEXP.makeid(150));
+      console.log(H5Pbridge.makeid(150));
     };
 
     $(function () {
@@ -287,29 +286,37 @@ function postEvent(message) {
 
 // Start of waitForMain mechanism
 // event listener listens to echoes from main.js
-var mainIsLoaded = 0; //TODO get rid of global var
-window.parent.parent.addEventListener('message', handleEchoMessage, true); //capturing phase
+// var mainIsLoaded = 0; //TODO get rid of global var
+// window.parent.parent.addEventListener('message', handleEchoMessage, true); //capturing phase
 
-function handleEchoMessage(event) {
-  if (event.data == 'echoFromMainEvent') {
-    mainIsLoaded += 1;
-    console.info('RECEIVE message echoFromMainEvent (formulaapplet-editor.js) mainIsLoaded=' + mainIsLoaded);
-  }
-}
+// function handleEchoMessage(event) {
+//   if (event.data == 'echoFromMainEvent') {
+//     mainIsLoaded += 1;
+//     console.info('RECEIVE message echoFromMainEvent (formulaapplet-editor.js) mainIsLoaded=' + mainIsLoaded);
+//   }
+// }
 
 //TODO get rid of global var
 var try_counter = 0;
 var try_counter_limit = 10;
 
 function waitForMainThenDo(cont) {
-  if (mainIsLoaded == 1) {
-    // execute callback only the first time called
+  var mainIsLoaded = false;
+  try {
+    mainIsLoaded = H5Pbridge.mainIsLoaded();
+  } catch (error) {
+    console.log(try_counter);
+    console.log(H5Pbridge);
+  }
+  if (mainIsLoaded) {
+    // execute callback
     cont();
   } else {
     try_counter++;
-    postEvent("SignalToMainEvent");
-    // send another echo to main.js. If echo comes back, mainIsLoaded = true
-    console.info('(1) post message SignalToMainEvent (formulaapplet-editor.js) try=' + try_counter);
+    // postEvent("SignalToMainEvent");
+    // // send another echo to main.js. If echo comes back, mainIsLoaded = true
+    // console.info('(1) post message SignalToMainEvent (formulaapplet-editor.js) try=' + try_counter);
+    console.info(`waitFarMain try_counter=${try_counter}`);
     if (try_counter < try_counter_limit) {
       setTimeout(function () {
         // recurse

--- a/h5p/development/H5PEditor.FormulaAppletEditor-1.1/scripts/formulaapplet-editor.js
+++ b/h5p/development/H5PEditor.FormulaAppletEditor-1.1/scripts/formulaapplet-editor.js
@@ -122,7 +122,8 @@ H5PEditor.widgets.formulaAppletEditor = H5PEditor.FormulaAppletEditor = (functio
     console.log('*** MAIN is loaded *** ');
     console.log(H5Pbridge);
     console.log('before triggering preparePageEvent');
-    postEvent("preparePageEvent");
+    // postEvent("preparePageEvent");
+    H5Pbridge.preparePage();
     var id = getputId.get();
     console.log(id);
     if (id !== 'nothingToDo') {
@@ -208,19 +209,6 @@ function afterAppend(obj) {
 
   //TODO bug: new_id is not replaced by a random id when generatingon a new formula applet
   //TODO bug: getField('id') has a random id but gets a new random id
-  // var id = getField('id');
-  // console.log('id.value=' + id.value);
-  // if (id.value == 'new_id') {
-  //   var newId = makeid(12);
-  //   console.log('new_id -> ' + newId);
-  //   id.value = id.$input[0].value = newId;
-  //   // causes TwoTimesPreparePage bug (lose result field )
-  //   console.log('obj.parent.params.id=' + obj.parent.params.id);
-  //   obj.parent.params.id = newId;
-  //   console.log('obj.parent.params.id=' + obj.parent.params.id);
-  //   console.log('postEvent idChangedEvent');
-  //   postEvent(["idChangedEvent", newId]);
-  // }
 
   window.addEventListener('message', setSolutionMessageHandler, false); //bubbling phase
 

--- a/main/.gitignore
+++ b/main/.gitignore
@@ -1,3 +1,6 @@
 node_modules
 public/build
 copyBundles.cmd
+docs
+package.bak
+

--- a/main/src/js/dom.js
+++ b/main/src/js/dom.js
@@ -48,8 +48,12 @@ export function findDoc() {
     return win.document;
 }
 
+// export function isH5P() {
+//     var h5p_classes = document.getElementsByClassName('h5p-content');
+//     var isH5P = (h5p_classes.length > 0);
+//     return isH5P; //publish
+// }
+
 export function isH5P() {
-    var h5p_classes = document.getElementsByClassName('h5p-content');
-    var isH5P = (h5p_classes.length > 0);
-    return isH5P; //publish
+    return ((typeof window.H5P) !== 'undefined');
 }

--- a/main/src/js/editor.js
+++ b/main/src/js/editor.js
@@ -1,6 +1,7 @@
 "use strict";
 
 import $ from "jquery";
+import config from "./config.json";
 
 import {
     domLoad,
@@ -54,6 +55,8 @@ function mathQuillifyEditor(fApp) {
     return editorMf;
 }
 
+
+
 export async function prepareEditorApplet(fApp) {
     // *** editor ***
     await initEditor();
@@ -67,6 +70,7 @@ export async function prepareEditorApplet(fApp) {
 
     // H5P stuff
     window.addEventListener('message', messageHandler, false); //bubbling phase
+    window.parent.parent.addEventListener('message', messageHandler, false); //bubbling phase
 
     var newLatex = 'new'; //TODO get rid of global vars
     function messageHandler(event) {
@@ -99,7 +103,7 @@ export async function prepareEditorApplet(fApp) {
             editorMf.latex(latex);
         }
 
-        
+
         // setInputFieldMouseoverEvent precedes setInputFieldEvent
         // global var newLatex is renewed by function setInput() 
         if (eventType == 'setInputFieldEvent') {
@@ -274,7 +278,7 @@ function getPositionOfUnitTags(latex, unitTag) {
 
 export function setUnit(mf) {
     var i, k;
-    var unitTag = '\\textcolor{blue}{';
+    var unitTag = config.unit_replacement;
     // erase class inputfield = false
     var temp = getSelection(mf, {
         erase: false
@@ -487,7 +491,7 @@ function getHTML(tex, tag, hasSolution) {
 
 export function makeid(length) {
     var result = 'fa';
-    var characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    var characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
     var numOfChars = characters.length;
     for (var i = 2; i < length; i++) {
         result += characters.charAt(Math.floor(Math.random() * numOfChars));

--- a/main/src/js/preparePage.js
+++ b/main/src/js/preparePage.js
@@ -66,7 +66,7 @@ function FApp() {
   this.unitAuto = false;
 }
 
-window.addEventListener('message', handleMessage, false); //bubbling phase
+// window.addEventListener('message', handleMessage, false); //bubbling phase
 
 // function handleMessage(event) {
 //   if (event.data == 'preparePageEvent') {

--- a/main/src/js/preparePage.js
+++ b/main/src/js/preparePage.js
@@ -68,12 +68,12 @@ function FApp() {
 
 window.addEventListener('message', handleMessage, false); //bubbling phase
 
-function handleMessage(event) {
-  if (event.data == 'preparePageEvent') {
-    console.info('RECEIVE MESSAGE preparePageEvent (preparePage.js)');
-    preparePage();
-  }
-}
+// function handleMessage(event) {
+//   if (event.data == 'preparePageEvent') {
+//     console.info('RECEIVE MESSAGE preparePageEvent (preparePage.js)');
+//     preparePage();
+//   }
+// }
 
 export default async function preparePage() {
   await domLoad;

--- a/main/src/main.js
+++ b/main/src/main.js
@@ -10,9 +10,13 @@ import {
 import {
     isH5P
 } from "./js/dom.js";
+import {
+    makeid
+} from "./js/editor.js";
 
 // H5Pbridge
-export { preparePage, mathQuillify };
+export { preparePage, mathQuillify, makeid };
+
 // debugger;
 
 window.onload = function () {
@@ -35,7 +39,7 @@ window.onload = function () {
             mathQuillify(id);
         });
 
-        window.addEventListener('message', handleMessage, false); //bubbling phase
+        // window.addEventListener('message', handleMessage, false); //bubbling phase
         // TODO this code causes bugs:
         // eslint-disable-next-line no-undef
         lang = H5P.jQuery('html')[0].getAttribute('xml:lang');
@@ -54,23 +58,23 @@ window.onload = function () {
     // This information is used by preparePage.js and translate.js/clickLanguage()
 };
 
-function handleMessage(event) {
-    // create echo
-    if (event.data == 'SignalToMainEvent') {
-        event.target.postMessage('echoFromMainEvent', event.origin);
-    }
-}
+// function handleMessage(event) {
+//     // create echo
+//     if (event.data == 'SignalToMainEvent') {
+//         event.target.postMessage('echoFromMainEvent', event.origin);
+//     }
+// }
 
-export function makeid(length) {
-    var result = 'fa';
-    var characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789____----';
-    var numOfChars = characters.length;
-    for (var i = 2; i < length; i++) {
-        result += characters.charAt(Math.floor(Math.random() * numOfChars));
-    }
-    // result = '"' + result + '"';
-    return result;
-}
+// export function makeid(length) {
+//     var result = 'fa';
+//     var characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789____----';
+//     var numOfChars = characters.length;
+//     for (var i = 2; i < length; i++) {
+//         result += characters.charAt(Math.floor(Math.random() * numOfChars));
+//     }
+//     // result = '"' + result + '"';
+//     return result;
+// }
 
 export function mainIsLoaded(){
     return true;

--- a/main/src/main.js
+++ b/main/src/main.js
@@ -12,7 +12,7 @@ import {
 } from "./js/dom.js";
 
 // H5Pbridge
-export { preparePage };
+export { preparePage, mathQuillify };
 // debugger;
 
 window.onload = function () {
@@ -61,10 +61,6 @@ function handleMessage(event) {
     }
 }
 
-// export default function main_square(x){
-//     return x*x;
-// }
-
 export function makeid(length) {
     var result = 'fa';
     var characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789____----';
@@ -74,5 +70,9 @@ export function makeid(length) {
     }
     // result = '"' + result + '"';
     return result;
+}
+
+export function mainIsLoaded(){
+    return true;
 }
 

--- a/main/src/main.js
+++ b/main/src/main.js
@@ -18,14 +18,14 @@ export { preparePage };
 window.onload = function () {
     var lang;
     if (isH5P()) {
-        // make sensitive for preparePageEvent
-        // eslint-disable-next-line no-undef
-        H5P.jQuery(document).on('preparePageEvent', function () {
-            console.log('RECEIVE preparePageEvent (main.js)');
-            // console.log('THIS SHOULD NOT HAPPEN because message events are used now!');
-            // but it is used by formulaapplet.js, chainTimer
-            preparePage();
-        });
+        // // make sensitive for preparePageEvent
+        // // eslint-disable-next-line no-undef
+        // H5P.jQuery(document).on('preparePageEvent', function () {
+        //     console.log('RECEIVE preparePageEvent (main.js)');
+        //     // console.log('THIS SHOULD NOT HAPPEN because message events are used now!');
+        //     // but it is used by formulaapplet.js, chainTimer
+        //     preparePage();
+        // });
         // eslint-disable-next-line no-undef, no-unused-vars
         H5P.jQuery(document).on('mathquillifyAllEvent', function (_ev) {
             mathQuillifyAll();


### PR DESCRIPTION
formulaapplet-editor: waitForMainThenDo() does not have to use messages and echo messages any more.
It may use H5Pbridge.mainIsLoaded() instead - much simpler.
formulaapplet.js: does not have to use chainTimer any more. Just call H5Pbridge.mathQuillify(id) in afterAppend(id), separat for every appended applet. Not necessary to wait for all applets to be loaded.
TODO: erase dead code.
Nice to have: improve findDoc() by using doc of editor applet and give it to mathquillify().
Simplify unstable management of id.
